### PR TITLE
bugfix: day.js parse constructor modified

### DIFF
--- a/projects/picker/src/lib/dayjs-adapter/dayjs-date-time-adapter.class.ts
+++ b/projects/picker/src/lib/dayjs-adapter/dayjs-date-time-adapter.class.ts
@@ -278,9 +278,7 @@ export class DayjsDateTimeAdapter extends DateTimeAdapter<dayjs.Dayjs> {
     }
 
     public parse(value: any, parseFormat: any): dayjs.Dayjs {
-        return dayjs(value, {
-            format: parseFormat
-        });
+        return dayjs(value, parseFormat);
     }
 
     private createDayjs(date: dayjs.Dayjs): dayjs.Dayjs {


### PR DESCRIPTION
## Changes 

Changed day.js constructor in adapter parse function

## Why?

### Local testing
Custom parse formats just plain and simple did not work with the current code for me. After local testing like this:
```typescript
// version currently used in adapter parse function
console.log(
	dayjs('10.05.2023', {
		format: 'DD.MM.YYYY',
	}),
);
// version conforming to documentation
console.log(dayjs('10.05.2023', 'DD.MM.YYYY'));
```
Only the second version worked and actually parsed the date with the right (German) format as 10th of May 2023 and **not** in the American format of 5th of October 2023.

### Typing

Also official typescript typing of day.js describes the possible API calls to construct a day.js object without the format as parameter property. See
https://github.com/iamkun/dayjs/blob/dev/types/index.d.ts#L7
(no format property. Just directly passing format string!)


## Note

This is **untested** since I could not get it to build and import locally (problems with node-sass, build, link).
However, this conforms to my local testing of day.js and what the documentation says:

1. Documentation here https://day.js.org/docs/en/plugin/custom-parse-format describes the syntax I modified it to
2. Local testing described above in "Why?" worked with the new, modified syntax