### PR TITLE
Implement & improve deserialize method

### DIFF
--- a/projects/picker/src/lib/dayjs-adapter/dayjs-date-time-adapter.class.ts
+++ b/projects/picker/src/lib/dayjs-adapter/dayjs-date-time-adapter.class.ts
@@ -173,6 +173,30 @@ export class DayjsDateTimeAdapter extends DateTimeAdapter<dayjs.Dayjs> {
         return dayjs.isDayjs(obj);
     }
 
+    /**
+     * Attempts to deserialize a value to a valid date object. This is different from parsing in that
+     * deserialize should only accept non-ambiguous, locale-independent formats (e.g. a ISO 8601
+     * string). The datepicker will call this method on all of it's `@Input()` properties that accept dates.
+     * It is therefore possible to support passing values from your backend directly to these properties by
+     * overriding this method to also deserialize the format used by your backend.
+     * In this dayjs adapter it accepts Dayjs objects or strings that can be input into the dayjs contructor (e.g. ISO 8601).
+     */
+    public deserialize(value: dayjs.Dayjs | null | string): dayjs.Dayjs | null {
+        if (typeof value === 'string') {
+            const constructedDayjs = dayjs(value);
+            return this.isValid(constructedDayjs)
+                ? constructedDayjs
+                : this.invalid();
+        } else if (
+            value == null ||
+            (this.isDateInstance(value) && this.isValid(value))
+        ) {
+            return value;
+        }
+
+        return this.invalid();
+    }
+
     public addCalendarYears(date: dayjs.Dayjs, amount: number): dayjs.Dayjs {
         return this.clone(date).add(amount, 'year');
     }


### PR DESCRIPTION
## Situation at the moment
Right now this adapter just uses the fallback native deserialize method.

## Why a problem
This leads to problems if you want to pass other valid
> non-ambiguous, locale-independent formats (e.g. a ISO 8601 strings)

([from](https://github.com/danielmoncada/date-time-picker/blob/master/projects/picker/src/lib/date-time/adapter/date-time-adapter.class.ts#L265))
from your backend as the date picker only accepts dayjs objects with this adapter in use.
This should not be the case I think as **most backend systems etc. save their date-times in ISO strings** and these can be **easily deserialized with dayjs** (just put into constructor).

## Solution implemented
Implementing a deserialize method in this adapter (overriding native deserialize method) can mitigate this issue. This PR allows dates to be input into the datepicker which are either dayjs objects  or strings that are accepted by the dayjs constructor. ISO 8601 strings for example fulfill this requirement

## Final notes
I could finally locally build it and run the serve command. For everyone struggling in future: **Switching to node 14** did it for me. This PR and the previous one #11 worked for me in the local ng serve demo app :pray: 