### PR TITLE
Bugfix in differenceInCalendarDays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmoncada/angular-datetime-picker-dayjs-adapter",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmoncada/angular-datetime-picker-dayjs-adapter",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Angular Date Time Picker (DayJs Adapter)",
   "keywords": [
     "Angular",

--- a/projects/picker/package.json
+++ b/projects/picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielmoncada/angular-datetime-picker-dayjs-adapter",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Angular Date Time Picker (DayJs Adpater)",
   "keywords": [
     "Angular",

--- a/projects/picker/src/lib/dayjs-adapter/dayjs-date-time-adapter.class.ts
+++ b/projects/picker/src/lib/dayjs-adapter/dayjs-date-time-adapter.class.ts
@@ -128,7 +128,9 @@ export class DayjsDateTimeAdapter extends DateTimeAdapter<dayjs.Dayjs> {
         dateLeft: dayjs.Dayjs,
         dateRight: dayjs.Dayjs
     ): number {
-        return Math.ceil(dateLeft.diff(dateRight, 'day', true));
+        return Math.ceil(
+            dateLeft.startOf('day').diff(dateRight.startOf('day'), 'day', true)
+        );
     }
 
     public getYearName(date: dayjs.Dayjs): string {


### PR DESCRIPTION
## Changes
Zero time of both left and right datetimes in `differenceInCalendarDays`

## Why
It should only compare the time (in days) between two _dates_ while **ignoring the possible timestamp** included in the supplied _datetimes_.

This way it should be consistent behavior with native implementation in parent datetimepicker lib [native-date-time-adapter.class.ts#L92-L96](https://github.com/danielmoncada/date-time-picker/blob/main/projects/picker/src/lib/date-time/adapter/native-date-time-adapter.class.ts#L92-L96)

###### sorry for the PR spam. I just want to get this to work in my employers app and spare others the pain